### PR TITLE
config: Add targeting for pip-compile repositories

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -28,5 +28,8 @@
         "patch"
       ]
     }
-  ]
+  ],
+  "pip-compile": {
+    "fileMatch": ["(^|/).*?requirements.*?\\.in$"]
+  }
 }


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
Renovate doesn't automatically detect pip-compile projects due to the lack of certainty of what the source files are. This adds file targeting for pip-compile to allow for maintaining the generated lock-files and update versions in the source specifications. https://docs.renovatebot.com/modules/manager/pip-compile/

# How can this be tested?
To validate the configuration you can run the config validator for Renovate - https://docs.renovatebot.com/config-validation/