### PR TITLE
Update renovate config to support Earthly files

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -31,5 +31,14 @@
   ],
   "pip-compile": {
     "fileMatch": ["(^|/).*?requirements.*?\\.in$"]
+  },
+  {
+  "docker": {
+    "fileMatch": [
+      "(^|/)Earthfile$",
+      "(^|/|\\.)Dockerfile$",
+      "(^|/)Dockerfile[^/]*$",
+      "(^|/|\\.)dockerfile[^/]*$"
+    ]
   }
 }


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
Adds configuration to Renovate that enables it to manage version updates for Earthly files as we are starting to adopt that tool in certain use cases. 