### PR TITLE
config: Remove pinning of Docker dependencies by hash

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,10 +1,13 @@
 {
   "assigneesFromCodeOwners": true,
+  "configMigration": true,
   "extends": [
     ":automergeMinor",
+    ":pinDevDependencies",
     ":rebaseStalePrs",
     ":separateMajorReleases",
-    "config:best-practices"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "schedule": [
     "every weekend"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Pinning Docker images to a specific hash will quickly become very noisy. This removes that setting while maintaining the other elements of the `best-practices` preset 
https://docs.renovatebot.com/presets-config/#configbest-practices