### PR TITLE
group ckeditor packages

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -42,6 +42,12 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "matchSourceUrlPrefixes": [
+        "https://github.com/ckeditor/ckeditor5/"
+      ],
+      "groupName": "ckeditor5"
     }
   ],
   "pip-compile": {


### PR DESCRIPTION
### What are the relevant tickets?
- https://github.com/mitodl/mit-open/issues/317

### Description (What does it do?)
This PR tells renovate to group CKeditor5 packages.

- Originally I added this in the MIT Open repo via https://github.com/mitodl/mit-open/pull/711. 
 
Since that seems to be working **and** we use CKeditor elsewhere (e.g., OCW Studio) I think it's worth adding this here. In general, renovate is useless on CKEditor **unless** the updates are grouped—The various packages generally need to have the same version.

### How can this be tested?
1. Observe that this worked in MIT: Open https://github.com/mitodl/mit-open/pull/795


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
