### PR TITLE
Don't allow automerges of python upgrades

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -61,6 +61,12 @@
       ],
       "allowedVersions": "!/1\\.3\\.14/",
       "automerge": false
+    },
+    {
+      "matchPackageNames": [
+        "python"
+      ],
+      "automerge": false
     }
   ],
   "pip-compile": {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8854

### Description (What does it do?)
<!--- Describe your changes in detail -->
This should prevent the automerging of python updates

