### PR TITLE
docs: fix placeholder text and inconsistent example in style guide

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -37,16 +37,16 @@ and preferences within our organization.
   attributes, and exceptions.
 * **Use PEP 257 docstrings:** This helps with automated documentation generation.
     ```python
-        def my_function(param1, param2):
+        def add(param1, param2):
             """Single-line summary.
 
             More detailed description, if necessary.
 
-            :param x: The first number.
-            :param y: The second number.
-            :return: The sum of x and y.
+            :param param1: The first number.
+            :param param2: The second number.
+            :return: The sum of param1 and param2.
 
-            :raises TypeError: If x or y is not a number.
+            :raises TypeError: If param1 or param2 is not a number.
 
             Example:
             >>> add(2, 3)
@@ -65,7 +65,7 @@ and preferences within our organization.
 * **Use complete sentences:** Start comments with a capital letter and use proper punctuation.
 
 ## Logging
-* **Use a standard logging framework:**  Company X uses the built-in `logging` module.
+* **Use a standard logging framework:**  MIT Open Learning uses the built-in `logging` module.
 * **Log at appropriate levels:** DEBUG, INFO, WARNING, ERROR, CRITICAL
 * **Provide context:** Include relevant information in log messages to aid debugging.
 


### PR DESCRIPTION
## Summary

Fix issues in `.gemini/styleguide.md`:

- Replace `Company X` placeholder with `MIT Open Learning` in the Logging section
- Fix inconsistent docstring example: function `my_function(param1, param2)` had mismatched parameter names and a different function name in usage example. Aligned throughout.

No functional changes — style guide documentation only.